### PR TITLE
feat: 新增幂等中间件，防止下单/支付重复提交

### DIFF
--- a/api/v1/idempotency.go
+++ b/api/v1/idempotency.go
@@ -1,0 +1,47 @@
+package v1
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/RedInn7/gomall/pkg/utils/ctl"
+	"github.com/RedInn7/gomall/pkg/utils/log"
+	"github.com/RedInn7/gomall/repository/cache"
+)
+
+// IdempotencyTokenHandler 颁发幂等 token，5 分钟有效
+func IdempotencyTokenHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		user, err := ctl.GetUserInfo(c.Request.Context())
+		if err != nil {
+			c.JSON(http.StatusOK, ErrorResponse(c, err))
+			return
+		}
+
+		buf := make([]byte, 16)
+		if _, err := rand.Read(buf); err != nil {
+			log.LogrusObj.Errorln(err)
+			c.JSON(http.StatusOK, ErrorResponse(c, err))
+			return
+		}
+		token := hex.EncodeToString(buf)
+
+		key := cache.IdempotencyTokenKey(user.Id, token)
+		if err := cache.IssueIdempotencyToken(c.Request.Context(), key); err != nil {
+			log.LogrusObj.Errorln(err)
+			c.JSON(http.StatusOK, ErrorResponse(c, err))
+			return
+		}
+		if err := cache.SetTokenTTL(c.Request.Context(), key); err != nil {
+			log.LogrusObj.Errorln(err)
+		}
+
+		c.JSON(http.StatusOK, ctl.RespSuccess(c, gin.H{
+			"idempotency_key": token,
+			"ttl_seconds":     int(cache.IdempotencyTokenTTL.Seconds()),
+		}))
+	}
+}

--- a/middleware/idempotency.go
+++ b/middleware/idempotency.go
@@ -1,0 +1,112 @@
+package middleware
+
+import (
+	"bytes"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/RedInn7/gomall/pkg/e"
+	"github.com/RedInn7/gomall/pkg/utils/ctl"
+	"github.com/RedInn7/gomall/pkg/utils/log"
+	"github.com/RedInn7/gomall/repository/cache"
+)
+
+const IdempotencyHeader = "Idempotency-Key"
+
+// responseRecorder 拷贝写入的响应体，便于幂等命中时回放
+type responseRecorder struct {
+	gin.ResponseWriter
+	body *bytes.Buffer
+}
+
+func (r *responseRecorder) Write(b []byte) (int, error) {
+	r.body.Write(b)
+	return r.ResponseWriter.Write(b)
+}
+
+func (r *responseRecorder) WriteString(s string) (int, error) {
+	r.body.WriteString(s)
+	return r.ResponseWriter.WriteString(s)
+}
+
+// Idempotency 幂等中间件：Header 中带 Idempotency-Key
+// 状态机由 cache.AcquireIdempotencyLock 中的 Lua 脚本驱动
+func Idempotency() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		token := c.GetHeader(IdempotencyHeader)
+		if token == "" {
+			c.JSON(http.StatusOK, gin.H{
+				"status": e.InvalidParams,
+				"msg":    e.GetMsg(e.InvalidParams),
+				"data":   "缺少 Idempotency-Key",
+			})
+			c.Abort()
+			return
+		}
+
+		user, err := ctl.GetUserInfo(c.Request.Context())
+		if err != nil {
+			c.JSON(http.StatusOK, gin.H{
+				"status": e.ErrorAuthCheckTokenFail,
+				"msg":    e.GetMsg(e.ErrorAuthCheckTokenFail),
+				"data":   "未获取到用户身份",
+			})
+			c.Abort()
+			return
+		}
+
+		key := cache.IdempotencyTokenKey(user.Id, token)
+		state, cached, err := cache.AcquireIdempotencyLock(c.Request.Context(), key)
+		if err != nil {
+			log.LogrusObj.Errorln("idempotency lua error:", err)
+			c.JSON(http.StatusOK, gin.H{
+				"status": e.ERROR,
+				"msg":    e.GetMsg(e.ERROR),
+				"data":   "幂等服务异常",
+			})
+			c.Abort()
+			return
+		}
+
+		switch state {
+		case 0:
+			c.JSON(http.StatusOK, gin.H{
+				"status": e.ErrIdempotencyTokenInvalid,
+				"msg":    e.GetMsg(e.ErrIdempotencyTokenInvalid),
+				"data":   "token 不存在或已过期",
+			})
+			c.Abort()
+			return
+		case 2:
+			c.Header("X-Idempotent-Replay", "true")
+			c.Data(http.StatusOK, "application/json; charset=utf-8", []byte(cached))
+			c.Abort()
+			return
+		case 3:
+			c.JSON(http.StatusOK, gin.H{
+				"status": e.ErrIdempotencyInProgress,
+				"msg":    e.GetMsg(e.ErrIdempotencyInProgress),
+				"data":   "请求正在处理中",
+			})
+			c.Abort()
+			return
+		}
+
+		recorder := &responseRecorder{ResponseWriter: c.Writer, body: bytes.NewBuffer(nil)}
+		c.Writer = recorder
+
+		c.Next()
+
+		if len(c.Errors) > 0 || recorder.Status() >= http.StatusBadRequest {
+			if err := cache.ReleaseIdempotencyLock(c.Request.Context(), key); err != nil {
+				log.LogrusObj.Errorln("idempotency release error:", err)
+			}
+			return
+		}
+
+		if err := cache.CommitIdempotencyResult(c.Request.Context(), key, recorder.body.String()); err != nil {
+			log.LogrusObj.Errorln("idempotency commit error:", err)
+		}
+	}
+}

--- a/pkg/e/code.go
+++ b/pkg/e/code.go
@@ -48,4 +48,8 @@ const (
 	//对象存储错误
 	ErrorOss        = 50001
 	ErrorUploadFile = 50002
+
+	// 幂等
+	ErrIdempotencyTokenInvalid = 60001
+	ErrIdempotencyInProgress   = 60002
 )

--- a/pkg/e/msg.go
+++ b/pkg/e/msg.go
@@ -44,6 +44,9 @@ var MsgFlags = map[int]string{
 	ErrorDatabase: "数据库操作出错,请重试",
 
 	ErrorOss: "OSS配置错误",
+
+	ErrIdempotencyTokenInvalid: "幂等token不存在或已过期",
+	ErrIdempotencyInProgress:   "请求正在处理中，请勿重复提交",
 }
 
 // GetMsg 获取状态码对应信息

--- a/repository/cache/idempotency.go
+++ b/repository/cache/idempotency.go
@@ -1,0 +1,90 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	IdempotencyStateInit       = "init"
+	IdempotencyStateProcessing = "processing"
+	IdempotencyStateDone       = "done"
+
+	IdempotencyTokenTTL  = 5 * time.Minute
+	IdempotencyResultTTL = 10 * time.Minute
+)
+
+var (
+	ErrIdempotencyTokenMissing    = errors.New("idempotency token 不存在或已过期")
+	ErrIdempotencyTokenInProgress = errors.New("请求正在处理中，请勿重复提交")
+)
+
+// acquireScript 原子地将 init → processing。
+// KEYS[1]=token key
+// 返回:
+//   1 = 成功获取（init → processing）
+//   2 = 已完成，返回缓存结果 (ARGV 中读 result 字段)
+//   3 = 正在处理中
+//   0 = 不存在
+var acquireScript = redis.NewScript(`
+local v = redis.call('HGET', KEYS[1], 'state')
+if v == false or v == nil then
+    return {0, ''}
+end
+if v == 'done' then
+    local r = redis.call('HGET', KEYS[1], 'result')
+    return {2, r or ''}
+end
+if v == 'processing' then
+    return {3, ''}
+end
+if v == 'init' then
+    redis.call('HSET', KEYS[1], 'state', 'processing')
+    redis.call('EXPIRE', KEYS[1], tonumber(ARGV[1]))
+    return {1, ''}
+end
+return {0, ''}
+`)
+
+// IssueIdempotencyToken 写入 init 状态
+func IssueIdempotencyToken(ctx context.Context, key string) error {
+	return RedisClient.HSet(ctx, key, "state", IdempotencyStateInit).Err()
+}
+
+// SetTokenTTL 为新建的 token 设置过期
+func SetTokenTTL(ctx context.Context, key string) error {
+	return RedisClient.Expire(ctx, key, IdempotencyTokenTTL).Err()
+}
+
+// AcquireIdempotencyLock 尝试占用 token，返回 (state, cachedResult)
+// state: 1 成功 / 2 已完成 / 3 处理中 / 0 不存在
+func AcquireIdempotencyLock(ctx context.Context, key string) (int64, string, error) {
+	res, err := acquireScript.Run(ctx, RedisClient, []string{key}, int(IdempotencyTokenTTL.Seconds())).Result()
+	if err != nil {
+		return 0, "", err
+	}
+	arr, ok := res.([]interface{})
+	if !ok || len(arr) != 2 {
+		return 0, "", errors.New("idempotency lua 返回值异常")
+	}
+	state, _ := arr[0].(int64)
+	cached, _ := arr[1].(string)
+	return state, cached, nil
+}
+
+// CommitIdempotencyResult 写入最终结果并设置 TTL
+func CommitIdempotencyResult(ctx context.Context, key, result string) error {
+	pipe := RedisClient.TxPipeline()
+	pipe.HSet(ctx, key, "state", IdempotencyStateDone, "result", result)
+	pipe.Expire(ctx, key, IdempotencyResultTTL)
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+// ReleaseIdempotencyLock 处理失败时回滚到 init，允许客户端用同一 token 重试
+func ReleaseIdempotencyLock(ctx context.Context, key string) error {
+	return RedisClient.HSet(ctx, key, "state", IdempotencyStateInit).Err()
+}

--- a/repository/cache/key.go
+++ b/repository/cache/key.go
@@ -11,7 +11,14 @@ const (
 	SkillProductKey     = "skill:product:%d"
 	SkillProductListKey = "skill:product_list"
 	SkillProductUserKey = "skill:user:%s"
+
+	// IdempotencyKey idempotency token，按用户隔离
+	IdempotencyKey = "idemp:%d:%s"
 )
+
+func IdempotencyTokenKey(userId uint, token string) string {
+	return fmt.Sprintf(IdempotencyKey, userId, token)
+}
 
 func ProductViewKey(id uint) string {
 	return fmt.Sprintf("view:product:%s", strconv.Itoa(int(id)))

--- a/routes/router.go
+++ b/routes/router.go
@@ -60,8 +60,11 @@ func NewRouter() *gin.Engine {
 			authed.POST("favorites/create", api.CreateFavoriteHandler())
 			authed.POST("favorites/delete", api.DeleteFavoriteHandler())
 
-			// 订单操作
-			authed.POST("orders/create", api.CreateOrderHandler())
+			// 幂等 token 颁发
+			authed.GET("idempotency/token", api.IdempotencyTokenHandler())
+
+			// 订单操作（下单走幂等）
+			authed.POST("orders/create", middleware.Idempotency(), api.CreateOrderHandler())
 			authed.GET("orders/list", api.ListOrdersHandler())
 			authed.GET("orders/old/list", api.ListOrdersHandlerOld())
 			authed.GET("orders/show", api.ShowOrderHandler())
@@ -79,8 +82,8 @@ func NewRouter() *gin.Engine {
 			authed.POST("addresses/update", api.UpdateAddressHandler())
 			authed.POST("addresses/delete", api.DeleteAddressHandler())
 
-			// 支付功能
-			authed.POST("paydown", api.OrderPaymentHandler())
+			// 支付功能（走幂等防重复扣款）
+			authed.POST("paydown", middleware.Idempotency(), api.OrderPaymentHandler())
 
 			// 显示金额
 			authed.POST("money", api.ShowMoneyHandler())


### PR DESCRIPTION
- 新增 GET /api/v1/idempotency/token 接口，返回 5 分钟有效的 Idempotency-Key
- 中间件通过 Redis Lua 脚本原子完成 init → processing → done 状态机
- 重复请求直接回放上次的响应体（X-Idempotent-Replay: true）
- 处理失败时回滚到 init，允许客户端用同一 token 重试
- orders/create、paydown 两个接口接入幂等中间件