### PR TITLE
feat: 新增 RabbitMQ 延迟队列订单超时关单

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,14 +2,17 @@ package main
 
 import (
 	"fmt"
+
+	_ "github.com/apache/skywalking-go"
+
 	conf "github.com/RedInn7/gomall/config"
 	"github.com/RedInn7/gomall/initialize"
 	util "github.com/RedInn7/gomall/pkg/utils/log"
 	snowflake "github.com/RedInn7/gomall/pkg/utils/snowflake"
 	"github.com/RedInn7/gomall/repository/cache"
 	"github.com/RedInn7/gomall/repository/db/dao"
+	"github.com/RedInn7/gomall/repository/rabbitmq"
 	"github.com/RedInn7/gomall/routes"
-	_ "github.com/apache/skywalking-go"
 )
 
 func main() {
@@ -26,7 +29,7 @@ func loading() {
 	cache.InitCache()
 	snowflake.InitSnowflake(1)
 	initialize.InitCron()
-	//rabbitmq.InitRabbitMQ() // 如果需要接入RabbitMQ可以打开这个注释
+	tryInitRabbitMQ()
 	//es.InitEs()             // 如果需要接入ELK可以打开这个注释
 	//kafka.InitKafka()
 	//track.InitJaeger()
@@ -37,4 +40,15 @@ func loading() {
 
 func scriptStarting() {
 	// 启动一些脚本
+}
+
+// tryInitRabbitMQ RabbitMQ 不可用时不阻塞启动，但放弃延迟队列能力
+func tryInitRabbitMQ() {
+	defer func() {
+		if r := recover(); r != nil {
+			util.LogrusObj.Warnf("RabbitMQ 初始化失败，订单延迟关单功能不可用: %v", r)
+		}
+	}()
+	rabbitmq.InitRabbitMQ()
+	initialize.InitOrderDelayConsumer()
 }

--- a/initialize/cron.go
+++ b/initialize/cron.go
@@ -2,9 +2,12 @@ package initialize
 
 import (
 	"fmt"
-	util "github.com/RedInn7/gomall/pkg/utils/log"
-	"github.com/RedInn7/gomall/service"
+
 	"github.com/robfig/cron/v3"
+
+	util "github.com/RedInn7/gomall/pkg/utils/log"
+	"github.com/RedInn7/gomall/repository/rabbitmq"
+	"github.com/RedInn7/gomall/service"
 )
 
 func InitCron() {
@@ -22,5 +25,15 @@ func InitCron() {
 		panic(fmt.Sprintf("Cron 初始化失败: %v", err))
 	}
 	c.Start()
+}
 
+// InitOrderDelayConsumer 声明延迟队列拓扑并启动消费者
+func InitOrderDelayConsumer() {
+	if err := rabbitmq.InitOrderDelayTopology(); err != nil {
+		util.LogrusObj.Errorf("InitOrderDelayTopology failed: %v", err)
+		return
+	}
+	if err := rabbitmq.ConsumeOrderCancelDelay(service.CancelUnpaidOrder); err != nil {
+		util.LogrusObj.Errorf("ConsumeOrderCancelDelay failed: %v", err)
+	}
 }

--- a/repository/db/dao/order.go
+++ b/repository/db/dao/order.go
@@ -169,6 +169,19 @@ func (dao *OrderDao) GetTimeoutOrders(minutes int, limit int) (orders []*model.O
 	return
 }
 
+// GetOrderByOrderNum 通过 order_num 查询订单
+func (dao *OrderDao) GetOrderByOrderNum(orderNum uint64) (*model.Order, error) {
+	var o model.Order
+	err := dao.DB.Model(&model.Order{}).Where("order_num=?", orderNum).First(&o).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &o, nil
+}
+
 func (dao *OrderDao) CloseOrderWithCheck(orderNum uint64) (bool, error) {
 	res := dao.DB.Model(&model.Order{}).Where(
 		"order_num=? and type=?", orderNum, consts.UnPaid).

--- a/repository/rabbitmq/order_delay.go
+++ b/repository/rabbitmq/order_delay.go
@@ -1,0 +1,105 @@
+package rabbitmq
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+
+	util "github.com/RedInn7/gomall/pkg/utils/log"
+)
+
+const (
+	orderDelayExchange = "order.delay.exchange"
+	orderDelayQueue    = "order.delay.queue"
+	orderDeadExchange  = "order.dead.exchange"
+	orderDeadQueue     = "order.dead.queue"
+	orderDeadRouting   = "order.dead"
+)
+
+// OrderCancelDelay 默认延迟时长（30 分钟）
+const OrderCancelDelay = 30 * time.Minute
+
+// InitOrderDelayTopology 声明延迟队列拓扑：
+//   producer → order.delay.exchange → order.delay.queue (TTL)
+//   过期 → order.dead.exchange → order.dead.queue → consumer
+func InitOrderDelayTopology() error {
+	ch, err := GlobalRabbitMQ.Channel()
+	if err != nil {
+		return err
+	}
+	defer ch.Close()
+
+	if err := ch.ExchangeDeclare(orderDelayExchange, "direct", true, false, false, false, nil); err != nil {
+		return err
+	}
+	if err := ch.ExchangeDeclare(orderDeadExchange, "direct", true, false, false, false, nil); err != nil {
+		return err
+	}
+
+	_, err = ch.QueueDeclare(orderDelayQueue, true, false, false, false, amqp.Table{
+		"x-dead-letter-exchange":    orderDeadExchange,
+		"x-dead-letter-routing-key": orderDeadRouting,
+	})
+	if err != nil {
+		return err
+	}
+	if err := ch.QueueBind(orderDelayQueue, "", orderDelayExchange, false, nil); err != nil {
+		return err
+	}
+
+	if _, err := ch.QueueDeclare(orderDeadQueue, true, false, false, false, nil); err != nil {
+		return err
+	}
+	return ch.QueueBind(orderDeadQueue, orderDeadRouting, orderDeadExchange, false, nil)
+}
+
+// PublishOrderCancelDelay 发布延迟取消任务
+func PublishOrderCancelDelay(ctx context.Context, orderNum uint64, delay time.Duration) error {
+	ch, err := GlobalRabbitMQ.Channel()
+	if err != nil {
+		return err
+	}
+	defer ch.Close()
+
+	return ch.PublishWithContext(ctx, orderDelayExchange, "", false, false, amqp.Publishing{
+		ContentType:  "text/plain",
+		DeliveryMode: amqp.Persistent,
+		Expiration:   strconv.FormatInt(delay.Milliseconds(), 10),
+		Body:         []byte(strconv.FormatUint(orderNum, 10)),
+	})
+}
+
+// ConsumeOrderCancelDelay 启动消费者，对每个超时订单调用 handler
+func ConsumeOrderCancelDelay(handler func(orderNum uint64) error) error {
+	ch, err := GlobalRabbitMQ.Channel()
+	if err != nil {
+		return err
+	}
+	if err := ch.Qos(16, 0, false); err != nil {
+		return err
+	}
+	msgs, err := ch.Consume(orderDeadQueue, "", false, false, false, false, nil)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		for d := range msgs {
+			orderNum, err := strconv.ParseUint(string(d.Body), 10, 64)
+			if err != nil {
+				util.LogrusObj.Errorln("delay queue body 不是合法 orderNum:", err)
+				_ = d.Nack(false, false)
+				continue
+			}
+			if err := handler(orderNum); err != nil {
+				util.LogrusObj.Errorf("处理延迟关单失败 orderNum=%d err=%v\n", orderNum, err)
+				_ = d.Nack(false, true) // requeue 一次，下游再决定是否进 DLX
+				continue
+			}
+			_ = d.Ack(false)
+		}
+	}()
+	return nil
+}

--- a/service/order.go
+++ b/service/order.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"errors"
-	"github.com/RedInn7/gomall/pkg/utils/snowflake"
 	"sync"
 	"time"
 
@@ -13,9 +12,11 @@ import (
 	"github.com/RedInn7/gomall/consts"
 	"github.com/RedInn7/gomall/pkg/utils/ctl"
 	util "github.com/RedInn7/gomall/pkg/utils/log"
+	"github.com/RedInn7/gomall/pkg/utils/snowflake"
 	"github.com/RedInn7/gomall/repository/cache"
 	"github.com/RedInn7/gomall/repository/db/dao"
 	"github.com/RedInn7/gomall/repository/db/model"
+	"github.com/RedInn7/gomall/repository/rabbitmq"
 	"github.com/RedInn7/gomall/types"
 )
 
@@ -64,6 +65,13 @@ func (s *OrderSrv) OrderCreate(ctx context.Context, req *types.OrderCreateReq) (
 	}
 	cache.RedisClient.ZAdd(cache.RedisContext, OrderTimeKey, data)
 
+	if rabbitmq.GlobalRabbitMQ != nil {
+		if pubErr := rabbitmq.PublishOrderCancelDelay(ctx, order.OrderNum, rabbitmq.OrderCancelDelay); pubErr != nil {
+			util.LogrusObj.Errorf("publish delay cancel failed orderNum=%d err=%v", order.OrderNum, pubErr)
+		}
+	}
+
+	resp = order
 	return
 }
 

--- a/service/order_cancel.go
+++ b/service/order_cancel.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"context"
+	"errors"
+
+	"gorm.io/gorm"
+
+	util "github.com/RedInn7/gomall/pkg/utils/log"
+	"github.com/RedInn7/gomall/repository/db/dao"
+)
+
+// CancelUnpaidOrder 真正执行关单 + 库存回滚，幂等。
+// 已支付 / 已取消 的订单会被 CloseOrderWithCheck 直接跳过。
+func CancelUnpaidOrder(orderNum uint64) error {
+	baseDao := dao.NewOrderDao(context.Background())
+	order, err := baseDao.GetOrderByOrderNum(orderNum)
+	if err != nil {
+		return err
+	}
+	if order == nil || order.ID == 0 {
+		return nil
+	}
+	return baseDao.DB.Transaction(func(tx *gorm.DB) error {
+		txOrderDao := dao.NewOrderDaoByDB(tx)
+		txProductDao := dao.NewProductDaoWithDB(tx)
+		ok, err := txOrderDao.CloseOrderWithCheck(orderNum)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
+		ok, err = txProductDao.RollbackStock(order.ProductID, order.Num)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			util.LogrusObj.Warnf("回滚库存失败 orderNum=%d", orderNum)
+			return errors.New("回滚库存失败")
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
- 新增 order.delay.exchange + order.delay.queue (TTL) -> order.dead.exchange + order.dead.queue 拓扑
- OrderCreate 时同时投递延迟消息，30 分钟后自动触发关单
- 关单逻辑封装到 service.CancelUnpaidOrder（关单 + 库存回滚 + 幂等）
- main 中 RabbitMQ 初始化失败不再阻塞启动，仅放弃延迟关单能力
- 保留原有 cron 巡检兜底，两套方案并存