### PR TITLE
feat: 商品详情接 Cache Aside 缓存，写路径走延迟双删

### DIFF
--- a/repository/cache/product.go
+++ b/repository/cache/product.go
@@ -1,0 +1,74 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	ProductDetailTTL     = 10 * time.Minute
+	ProductLockTTL       = 3 * time.Second
+	ProductDelayInterval = 500 * time.Millisecond
+)
+
+func ProductDetailKey(id uint) string {
+	return fmt.Sprintf("product:detail:%d", id)
+}
+
+func ProductLockKey(id uint) string {
+	return fmt.Sprintf("product:lock:%d", id)
+}
+
+var ErrProductCacheMiss = errors.New("product cache miss")
+
+// GetProductDetail 读缓存。未命中返回 ErrProductCacheMiss
+func GetProductDetail(ctx context.Context, id uint, dst interface{}) error {
+	raw, err := RedisClient.Get(ctx, ProductDetailKey(id)).Result()
+	if err == redis.Nil {
+		return ErrProductCacheMiss
+	}
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal([]byte(raw), dst)
+}
+
+// SetProductDetail 写缓存
+func SetProductDetail(ctx context.Context, id uint, val interface{}) error {
+	b, err := json.Marshal(val)
+	if err != nil {
+		return err
+	}
+	return RedisClient.Set(ctx, ProductDetailKey(id), b, ProductDetailTTL).Err()
+}
+
+// DelProductDetail 删缓存
+func DelProductDetail(ctx context.Context, id uint) error {
+	return RedisClient.Del(ctx, ProductDetailKey(id)).Err()
+}
+
+// TryProductLock 用 SETNX 抢回源锁，避免缓存击穿时多个请求同时回源
+func TryProductLock(ctx context.Context, id uint) (bool, error) {
+	return RedisClient.SetNX(ctx, ProductLockKey(id), "1", ProductLockTTL).Result()
+}
+
+func UnlockProduct(ctx context.Context, id uint) {
+	RedisClient.Del(ctx, ProductLockKey(id))
+}
+
+// DoubleDeleteAsync 延迟双删：写库后已经做了第一次删除，这里在 interval 后再删一次，
+// 用于覆盖"读旧值的并发请求把旧值塞回缓存"的窗口。
+func DoubleDeleteAsync(id uint, interval time.Duration) {
+	if interval <= 0 {
+		interval = ProductDelayInterval
+	}
+	go func() {
+		time.Sleep(interval)
+		_ = RedisClient.Del(context.Background(), ProductDetailKey(id)).Err()
+	}()
+}

--- a/service/product.go
+++ b/service/product.go
@@ -6,12 +6,14 @@ import (
 	"mime/multipart"
 	"strconv"
 	"sync"
+	"time"
 
 	conf "github.com/RedInn7/gomall/config"
 	"github.com/RedInn7/gomall/consts"
 	"github.com/RedInn7/gomall/pkg/utils/ctl"
 	"github.com/RedInn7/gomall/pkg/utils/log"
 	util "github.com/RedInn7/gomall/pkg/utils/upload"
+	"github.com/RedInn7/gomall/repository/cache"
 	"github.com/RedInn7/gomall/repository/db/dao"
 	"github.com/RedInn7/gomall/repository/db/model"
 	"github.com/RedInn7/gomall/types"
@@ -30,12 +32,43 @@ func GetProductSrv() *ProductSrv {
 	return ProductSrvIns
 }
 
-// ProductShow 商品
+// ProductShow Cache Aside 读取商品详情。
+//   1. 先读缓存，命中直接返回
+//   2. 未命中: SETNX 抢回源锁，单飞回源 DB
+//   3. 未抢到锁的请求短暂重试一次，仍未命中则直接回源（兜底）
 func (s *ProductSrv) ProductShow(ctx context.Context, req *types.ProductShowReq) (resp interface{}, err error) {
-	p, err := dao.NewProductDao(ctx).ShowProductById(req.ID)
+	cached := &types.ProductResp{}
+	if cacheErr := cache.GetProductDetail(ctx, req.ID, cached); cacheErr == nil {
+		return cached, nil
+	} else if cacheErr != cache.ErrProductCacheMiss {
+		log.LogrusObj.Warnln("read product cache failed:", cacheErr)
+	}
+
+	locked, _ := cache.TryProductLock(ctx, req.ID)
+	if !locked {
+		time.Sleep(50 * time.Millisecond)
+		if cacheErr := cache.GetProductDetail(ctx, req.ID, cached); cacheErr == nil {
+			return cached, nil
+		}
+	} else {
+		defer cache.UnlockProduct(ctx, req.ID)
+	}
+
+	pResp, err := s.loadProductFromDB(ctx, req.ID)
+	if err != nil {
+		return nil, err
+	}
+	if setErr := cache.SetProductDetail(ctx, req.ID, pResp); setErr != nil {
+		log.LogrusObj.Warnln("write product cache failed:", setErr)
+	}
+	return pResp, nil
+}
+
+func (s *ProductSrv) loadProductFromDB(ctx context.Context, id uint) (*types.ProductResp, error) {
+	p, err := dao.NewProductDao(ctx).ShowProductById(id)
 	if err != nil {
 		log.LogrusObj.Error(err)
-		return
+		return nil, err
 	}
 	pResp := &types.ProductResp{
 		ID:            p.ID,
@@ -58,10 +91,7 @@ func (s *ProductSrv) ProductShow(ctx context.Context, req *types.ProductShowReq)
 		pResp.BossAvatar = conf.Config.PhotoPath.PhotoHost + conf.Config.System.HttpPort + conf.Config.PhotoPath.AvatarPath + pResp.BossAvatar
 		pResp.ImgPath = conf.Config.PhotoPath.PhotoHost + conf.Config.System.HttpPort + conf.Config.PhotoPath.ProductPath + pResp.ImgPath
 	}
-
-	resp = pResp
-
-	return
+	return pResp, nil
 }
 
 // 创建商品
@@ -202,7 +232,7 @@ func (s *ProductSrv) ProductList(ctx context.Context, req *types.ProductListReq)
 	return
 }
 
-// ProductDelete 删除商品
+// ProductDelete 删除商品 + 删缓存
 func (s *ProductSrv) ProductDelete(ctx context.Context, req *types.ProductDeleteReq) (resp interface{}, err error) {
 	u, err := ctl.GetUserInfo(ctx)
 	if err != nil {
@@ -214,10 +244,15 @@ func (s *ProductSrv) ProductDelete(ctx context.Context, req *types.ProductDelete
 		log.LogrusObj.Error(err)
 		return
 	}
+	_ = cache.DelProductDetail(ctx, req.ID)
+	cache.DoubleDeleteAsync(req.ID, 0)
 	return
 }
 
-// 更新商品
+// ProductUpdate 更新商品，延迟双删保证缓存一致性
+//   1. 先删缓存
+//   2. 写库
+//   3. 异步等 500ms 再删一次（覆盖并发读取旧值后写回的窗口）
 func (s *ProductSrv) ProductUpdate(ctx context.Context, req *types.ProductUpdateReq) (resp interface{}, err error) {
 	product := &model.Product{
 		Name:       req.Name,
@@ -229,11 +264,13 @@ func (s *ProductSrv) ProductUpdate(ctx context.Context, req *types.ProductUpdate
 		DiscountPrice: req.DiscountPrice,
 		OnSale:        req.OnSale,
 	}
+	_ = cache.DelProductDetail(ctx, req.ID)
 	err = dao.NewProductDao(ctx).UpdateProduct(req.ID, product)
 	if err != nil {
 		log.LogrusObj.Error(err)
 		return
 	}
+	cache.DoubleDeleteAsync(req.ID, 0)
 
 	return
 }


### PR DESCRIPTION
- 新增 product:detail:{id} 缓存（TTL 10 分钟）
- 读路径: 缓存未命中时 SETNX 抢回源锁，单飞回源 DB，未抢到锁的请求短暂重试
- 写路径: 删缓存 → 写库 → 500ms 后异步再删一次，覆盖并发读旧值写回的窗口
- ProductDelete 同样走删 + 延迟双删