### PR TITLE
feat: 新增基于角色的后台访问控制 (RBAC) 与管理员 API

### DIFF
--- a/api/v1/admin.go
+++ b/api/v1/admin.go
@@ -1,0 +1,52 @@
+package v1
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/RedInn7/gomall/pkg/utils/ctl"
+	"github.com/RedInn7/gomall/service"
+)
+
+func AdminListUsersHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+		size, _ := strconv.Atoi(c.DefaultQuery("page_size", "50"))
+		resp, err := service.GetAdminSrv().ListAllUsers(c.Request.Context(), page, size)
+		if err != nil {
+			c.JSON(http.StatusOK, ErrorResponse(c, err))
+			return
+		}
+		c.JSON(http.StatusOK, ctl.RespSuccess(c, resp))
+	}
+}
+
+func AdminPromoteUserHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req struct {
+			UserId uint `json:"user_id" form:"user_id" binding:"required"`
+		}
+		if err := c.ShouldBind(&req); err != nil {
+			c.JSON(http.StatusOK, ErrorResponse(c, err))
+			return
+		}
+		if err := service.GetAdminSrv().PromoteToAdmin(c.Request.Context(), req.UserId); err != nil {
+			c.JSON(http.StatusOK, ErrorResponse(c, err))
+			return
+		}
+		c.JSON(http.StatusOK, ctl.RespSuccess(c, gin.H{"promoted": req.UserId}))
+	}
+}
+
+// BootstrapAdminHandler 仅当系统无 admin 时可用
+func BootstrapAdminHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if err := service.GetAdminSrv().BootstrapPromoteSelf(c.Request.Context()); err != nil {
+			c.JSON(http.StatusOK, ErrorResponse(c, err))
+			return
+		}
+		c.JSON(http.StatusOK, ctl.RespSuccess(c, gin.H{"ok": true}))
+	}
+}

--- a/middleware/rbac.go
+++ b/middleware/rbac.go
@@ -1,0 +1,91 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/RedInn7/gomall/pkg/e"
+	"github.com/RedInn7/gomall/pkg/utils/ctl"
+	"github.com/RedInn7/gomall/pkg/utils/log"
+	"github.com/RedInn7/gomall/repository/db/dao"
+)
+
+type roleCacheEntry struct {
+	role    string
+	expires time.Time
+}
+
+var (
+	roleCache   sync.Map
+	roleCacheTTL = 30 * time.Second
+)
+
+// lookupRole 带短 TTL 内存缓存，避免每个请求都打 DB
+func lookupRole(ctx context.Context, userId uint) (string, error) {
+	if v, ok := roleCache.Load(userId); ok {
+		entry := v.(roleCacheEntry)
+		if time.Now().Before(entry.expires) {
+			return entry.role, nil
+		}
+	}
+	u, err := dao.NewUserDao(ctx).GetUserById(userId)
+	if err != nil {
+		return "", err
+	}
+	role := u.Role
+	if role == "" {
+		role = "user"
+	}
+	roleCache.Store(userId, roleCacheEntry{role: role, expires: time.Now().Add(roleCacheTTL)})
+	return role, nil
+}
+
+// RequireRole 角色访问控制中间件，允许列表内的任一角色通过
+func RequireRole(allowed ...string) gin.HandlerFunc {
+	allowSet := make(map[string]struct{}, len(allowed))
+	for _, r := range allowed {
+		allowSet[r] = struct{}{}
+	}
+	return func(c *gin.Context) {
+		user, err := ctl.GetUserInfo(c.Request.Context())
+		if err != nil {
+			c.JSON(http.StatusOK, gin.H{
+				"status": e.ErrorAuthCheckTokenFail,
+				"msg":    e.GetMsg(e.ErrorAuthCheckTokenFail),
+				"data":   "未识别用户身份",
+			})
+			c.Abort()
+			return
+		}
+		role, err := lookupRole(c.Request.Context(), user.Id)
+		if err != nil {
+			log.LogrusObj.Errorln("rbac lookup role failed:", err)
+			c.JSON(http.StatusOK, gin.H{
+				"status": e.ERROR,
+				"msg":    e.GetMsg(e.ERROR),
+				"data":   "权限校验异常",
+			})
+			c.Abort()
+			return
+		}
+		if _, ok := allowSet[role]; !ok {
+			c.JSON(http.StatusOK, gin.H{
+				"status": e.ErrorAuthInsufficientAuthority,
+				"msg":    e.GetMsg(e.ErrorAuthInsufficientAuthority),
+				"data":   "需要管理员权限",
+			})
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}
+
+// InvalidateRoleCache 用户角色变更后调用，让缓存立即失效
+func InvalidateRoleCache(userId uint) {
+	roleCache.Delete(userId)
+}

--- a/repository/db/model/user.go
+++ b/repository/db/model/user.go
@@ -20,12 +20,15 @@ type User struct {
 	Status         string
 	Avatar         string `gorm:"size:1000"`
 	Money          string
+	Role           string `gorm:"size:16;default:'user';index"`
 	Relations      []User `gorm:"many2many:relation;"`
 }
 
 const (
-	PassWordCost        = 12       // 密码加密难度
-	Active       string = "active" // 激活用户
+	PassWordCost         = 12       // 密码加密难度
+	Active        string = "active" // 激活用户
+	RoleUser      string = "user"
+	RoleAdmin     string = "admin"
 )
 
 // SetPassword 设置密码

--- a/routes/router.go
+++ b/routes/router.go
@@ -117,6 +117,17 @@ func NewRouter() *gin.Engine {
 					ByUser: true,
 				}),
 				api.SkillProductHandler())
+
+			// 初始 admin 引导（仅在系统无 admin 时可用）
+			authed.POST("admin/bootstrap", api.BootstrapAdminHandler())
+
+			// 管理员后台
+			admin := authed.Group("/admin")
+			admin.Use(middleware.RequireRole("admin"))
+			{
+				admin.GET("users", api.AdminListUsersHandler())
+				admin.POST("users/promote", api.AdminPromoteUserHandler())
+			}
 		}
 	}
 	return r

--- a/service/admin.go
+++ b/service/admin.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/RedInn7/gomall/middleware"
+	"github.com/RedInn7/gomall/pkg/utils/ctl"
+	"github.com/RedInn7/gomall/pkg/utils/log"
+	"github.com/RedInn7/gomall/repository/db/dao"
+	"github.com/RedInn7/gomall/repository/db/model"
+)
+
+var (
+	adminSrvIns  *AdminSrv
+	adminSrvOnce sync.Once
+)
+
+type AdminSrv struct{}
+
+func GetAdminSrv() *AdminSrv {
+	adminSrvOnce.Do(func() { adminSrvIns = &AdminSrv{} })
+	return adminSrvIns
+}
+
+// ListAllUsers admin 接口：列出所有用户（不含密码摘要）
+func (s *AdminSrv) ListAllUsers(ctx context.Context, page, pageSize int) (interface{}, error) {
+	if page <= 0 {
+		page = 1
+	}
+	if pageSize <= 0 || pageSize > 200 {
+		pageSize = 50
+	}
+	var users []*model.User
+	db := dao.NewUserDao(ctx).DB
+	err := db.Model(&model.User{}).
+		Select("id, user_name, nick_name, email, status, role, created_at").
+		Offset((page - 1) * pageSize).
+		Limit(pageSize).
+		Order("id DESC").
+		Find(&users).Error
+	return users, err
+}
+
+// PromoteToAdmin 把指定用户提升为 admin。仅 admin 可调用（路由层已限）。
+func (s *AdminSrv) PromoteToAdmin(ctx context.Context, targetUserId uint) error {
+	target, err := dao.NewUserDao(ctx).GetUserById(targetUserId)
+	if err != nil {
+		return err
+	}
+	if target == nil || target.ID == 0 {
+		return errors.New("目标用户不存在")
+	}
+	target.Role = model.RoleAdmin
+	if err := dao.NewUserDao(ctx).UpdateUserById(targetUserId, target); err != nil {
+		return err
+	}
+	middleware.InvalidateRoleCache(targetUserId)
+	log.LogrusObj.Infof("user %d promoted to admin", targetUserId)
+	return nil
+}
+
+// BootstrapPromoteSelf 当系统中尚无 admin 时，允许任意已登录用户把自己提升为 admin，方便初始化。
+// 一旦存在 admin，本接口立即不可用。
+func (s *AdminSrv) BootstrapPromoteSelf(ctx context.Context) error {
+	u, err := ctl.GetUserInfo(ctx)
+	if err != nil {
+		return err
+	}
+	db := dao.NewUserDao(ctx).DB
+	var count int64
+	if err := db.Model(&model.User{}).Where("role = ?", model.RoleAdmin).Count(&count).Error; err != nil {
+		return err
+	}
+	if count > 0 {
+		return errors.New("系统已存在 admin，禁止使用 bootstrap 接口")
+	}
+	return s.PromoteToAdmin(ctx, u.Id)
+}


### PR DESCRIPTION
- User 模型新增 role 列 (默认 user)，新增 RoleUser/RoleAdmin 常量
- middleware.RequireRole 中间件带 30s 内存缓存，避免每请求查 DB
- /admin/users 列表 + /admin/users/promote 管理员晋升
- /admin/bootstrap 首次部署时允许已登录用户把自己设为 admin (有 admin 后立即失效)
- 角色变更后调用 InvalidateRoleCache，避免缓存延迟