### PR TITLE
fix: 调整 util.InitLog 顺序，避免 tryInitRabbitMQ 的 recover 时 LogrusObj 还是 nil

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ func main() {
 // loading一些配置
 func loading() {
 	conf.InitConfig()
+	util.InitLog() // 必须在使用 LogrusObj 的初始化之前完成
 	dao.InitMySQL()
 	cache.InitCache()
 	snowflake.InitSnowflake(1)
@@ -33,7 +34,6 @@ func loading() {
 	//es.InitEs()             // 如果需要接入ELK可以打开这个注释
 	//kafka.InitKafka()
 	//track.InitJaeger()
-	util.InitLog() // 如果接入ELK请进入这个func打开注释
 	fmt.Println("加载配置完成...")
 	//go scriptStarting()
 }


### PR DESCRIPTION
PR #51 引入了 tryInitRabbitMQ()，其 recover 调用了 util.LogrusObj.Warnf。 原 cmd/main.go 把 util.InitLog() 放在 tryInitRabbitMQ 之后，导致 RMQ 不可用时 recover 内部再次 panic（nil pointer），进程退出。

将 util.InitLog() 移到所有可能使用 LogrusObj 的初始化之前。