### PR TITLE
feat: 新增 Outbox 模式，保证业务写入与事件发布的最终一致

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	_ "github.com/apache/skywalking-go"
@@ -31,6 +32,7 @@ func loading() {
 	snowflake.InitSnowflake(1)
 	initialize.InitCron()
 	tryInitRabbitMQ()
+	initialize.InitOutboxPublisher(context.Background())
 	//es.InitEs()             // 如果需要接入ELK可以打开这个注释
 	//kafka.InitKafka()
 	//track.InitJaeger()

--- a/initialize/outbox.go
+++ b/initialize/outbox.go
@@ -1,0 +1,30 @@
+package initialize
+
+import (
+	"context"
+	"time"
+
+	util "github.com/RedInn7/gomall/pkg/utils/log"
+	"github.com/RedInn7/gomall/repository/rabbitmq"
+	"github.com/RedInn7/gomall/service/outbox"
+)
+
+var globalPublisher *outbox.Publisher
+
+// InitOutboxPublisher RMQ 不可用时不启动；用户后续修复 RMQ 后重启即可
+func InitOutboxPublisher(ctx context.Context) {
+	if rabbitmq.GlobalRabbitMQ == nil {
+		util.LogrusObj.Warnln("RabbitMQ 未初始化，跳过 Outbox publisher 启动")
+		return
+	}
+	if err := rabbitmq.InitDomainEventsExchange(); err != nil {
+		util.LogrusObj.Errorf("InitDomainEventsExchange failed: %v", err)
+		return
+	}
+	globalPublisher = outbox.New(outbox.PublisherConfig{
+		PollInterval: time.Second,
+		BatchSize:    100,
+	})
+	globalPublisher.Start(ctx)
+	util.LogrusObj.Infoln("Outbox publisher started")
+}

--- a/repository/db/dao/outbox.go
+++ b/repository/db/dao/outbox.go
@@ -1,0 +1,86 @@
+package dao
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/RedInn7/gomall/repository/db/model"
+)
+
+type OutboxDao struct {
+	*gorm.DB
+}
+
+func NewOutboxDao(ctx context.Context) *OutboxDao {
+	return &OutboxDao{NewDBClient(ctx)}
+}
+
+func NewOutboxDaoByDB(db *gorm.DB) *OutboxDao {
+	return &OutboxDao{db}
+}
+
+// Insert 在调用方提供的 tx 上插入事件，保证与业务写同一原子提交
+func (d *OutboxDao) Insert(aggregateType, eventType, routingKey string, aggregateID uint, payload any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	e := &model.OutboxEvent{
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+		EventType:     eventType,
+		RoutingKey:    routingKey,
+		Payload:       string(body),
+		Status:        model.OutboxStatusPending,
+		NextRetryAt:   time.Now(),
+	}
+	return d.DB.Create(e).Error
+}
+
+// FetchBatch 取出 limit 个待发布事件 (pending + 已到重试时间)，按 id 升序保证 FIFO
+func (d *OutboxDao) FetchBatch(limit int) ([]*model.OutboxEvent, error) {
+	var rows []*model.OutboxEvent
+	err := d.DB.Where("status = ? AND next_retry_at <= ?", model.OutboxStatusPending, time.Now()).
+		Order("id ASC").
+		Limit(limit).
+		Find(&rows).Error
+	return rows, err
+}
+
+func (d *OutboxDao) MarkSent(id uint) error {
+	return d.DB.Model(&model.OutboxEvent{}).Where("id = ?", id).
+		Updates(map[string]any{
+			"status":     model.OutboxStatusSent,
+			"updated_at": time.Now(),
+		}).Error
+}
+
+// MarkFailed 增加 attempts，超过 maxAttempts 标记为 dead；否则按指数退避设置 next_retry_at
+func (d *OutboxDao) MarkFailed(id uint, attempts, maxAttempts int, errMsg string) error {
+	now := time.Now()
+	updates := map[string]any{
+		"attempts":   attempts + 1,
+		"last_error": truncate(errMsg, 500),
+		"updated_at": now,
+	}
+	if attempts+1 >= maxAttempts {
+		updates["status"] = model.OutboxStatusDead
+	} else {
+		backoff := time.Duration(1<<attempts) * time.Second
+		if backoff > 5*time.Minute {
+			backoff = 5 * time.Minute
+		}
+		updates["next_retry_at"] = now.Add(backoff)
+	}
+	return d.DB.Model(&model.OutboxEvent{}).Where("id = ?", id).Updates(updates).Error
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/repository/db/dao/outbox_migrate_test.go
+++ b/repository/db/dao/outbox_migrate_test.go
@@ -1,0 +1,22 @@
+package dao
+
+import (
+	"testing"
+
+	conf "github.com/RedInn7/gomall/config"
+	"github.com/RedInn7/gomall/repository/db/model"
+)
+
+func TestOutbox_Migrate(t *testing.T) {
+	if _db == nil {
+		re := conf.ConfigReader{FileName: "../../../config/locales/config.yaml"}
+		conf.InitConfigForTest(&re)
+		InitMySQL()
+	}
+	if err := _db.AutoMigrate(&model.OutboxEvent{}); err != nil {
+		t.Fatalf("explicit AutoMigrate failed: %v", err)
+	}
+	if !_db.Migrator().HasTable(&model.OutboxEvent{}) {
+		t.Fatal("HasTable returned false after AutoMigrate")
+	}
+}

--- a/repository/db/dao/outbox_test.go
+++ b/repository/db/dao/outbox_test.go
@@ -1,0 +1,123 @@
+package dao
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	conf "github.com/RedInn7/gomall/config"
+	"github.com/RedInn7/gomall/repository/db/model"
+)
+
+func initDBForTest(t *testing.T) {
+	t.Helper()
+	if _db != nil {
+		return
+	}
+	re := conf.ConfigReader{FileName: "../../../config/locales/config.yaml"}
+	conf.InitConfigForTest(&re)
+	defer func() {
+		if r := recover(); r != nil {
+			t.Skipf("MySQL not available: %v", r)
+		}
+	}()
+	InitMySQL()
+}
+
+func TestOutbox_InsertFetchMarkSent(t *testing.T) {
+	initDBForTest(t)
+	if _db == nil {
+		t.Skip("MySQL not initialized")
+	}
+	ctx := context.Background()
+	d := NewOutboxDao(ctx)
+
+	type payload struct {
+		OrderNum uint64 `json:"order_num"`
+	}
+	if err := d.Insert("order", "OrderCreated", "order.created", 1, payload{OrderNum: 42}); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	rows, err := d.FetchBatch(50)
+	if err != nil {
+		t.Fatalf("FetchBatch: %v", err)
+	}
+	if len(rows) == 0 {
+		t.Fatal("expected at least one pending row")
+	}
+
+	var target *model.OutboxEvent
+	for _, r := range rows {
+		if r.RoutingKey == "order.created" && r.AggregateID == 1 {
+			target = r
+			break
+		}
+	}
+	if target == nil {
+		t.Fatal("inserted row not found in FetchBatch result")
+	}
+	if err := d.MarkSent(target.ID); err != nil {
+		t.Fatalf("MarkSent: %v", err)
+	}
+
+	// 重新 FetchBatch 不应再包含这一条
+	rows2, _ := d.FetchBatch(50)
+	for _, r := range rows2 {
+		if r.ID == target.ID {
+			t.Fatal("marked-sent row still appears in FetchBatch")
+		}
+	}
+}
+
+func TestOutbox_MarkFailedBackoff(t *testing.T) {
+	initDBForTest(t)
+	if _db == nil {
+		t.Skip()
+	}
+	ctx := context.Background()
+	d := NewOutboxDao(ctx)
+	if err := d.Insert("test", "Probe", "test.probe", 7, map[string]any{"k": "v"}); err != nil {
+		t.Fatal(err)
+	}
+	rows, _ := d.FetchBatch(100)
+	var target *model.OutboxEvent
+	for _, r := range rows {
+		if r.AggregateID == 7 && r.RoutingKey == "test.probe" {
+			target = r
+			break
+		}
+	}
+	if target == nil {
+		t.Skip("inserted row not found in fetch")
+	}
+
+	// 失败一次：attempts=1, 不会被立刻 fetch 出来
+	if err := d.MarkFailed(target.ID, 0, 3, "boom"); err != nil {
+		t.Fatalf("MarkFailed: %v", err)
+	}
+	rows, _ = d.FetchBatch(200)
+	for _, r := range rows {
+		if r.ID == target.ID {
+			t.Errorf("backoff not respected: row id=%d picked up immediately after fail", r.ID)
+		}
+	}
+
+	// 越限标记为 dead
+	if err := d.MarkFailed(target.ID, 2, 3, "boom"); err != nil {
+		t.Fatal(err)
+	}
+	var fresh model.OutboxEvent
+	d.DB.First(&fresh, target.ID)
+	if fresh.Status != model.OutboxStatusDead {
+		t.Fatalf("expect dead status, got %d", fresh.Status)
+	}
+	// 等到 backoff 过期也不应被 Fetch（已 dead）
+	time.Sleep(50 * time.Millisecond)
+	rows, _ = d.FetchBatch(200)
+	for _, r := range rows {
+		if r.ID == target.ID {
+			t.Errorf("dead event must not be re-fetched")
+		}
+	}
+}

--- a/repository/db/model/outbox.go
+++ b/repository/db/model/outbox.go
@@ -1,0 +1,37 @@
+package model
+
+import (
+	"time"
+
+	"github.com/jinzhu/gorm"
+)
+
+const (
+	OutboxStatusPending = 1
+	OutboxStatusSent    = 2
+	OutboxStatusDead    = 3
+
+	OutboxDefaultMaxAttempts = 10
+)
+
+// OutboxEvent 与业务写在同一个事务里，由后台 publisher 异步投递。
+//   aggregate_type + aggregate_id: 这条事件属于哪个聚合根
+//   event_type:                    具体动作 (OrderCreated / StockReserved / ProductUpdated 等)
+//   routing_key:                   投递到 domain.events 交换机时使用 (默认 aggregate_type.event_type)
+//   payload:                       JSON 序列化的事件 body
+//   status:                        1 pending / 2 sent / 3 dead
+//   next_retry_at:                 下一次允许重试的时间
+type OutboxEvent struct {
+	gorm.Model
+	AggregateType string    `gorm:"size:64;not null;index:idx_outbox_dispatch,priority:2"`
+	AggregateID   uint      `gorm:"not null"`
+	EventType     string    `gorm:"size:64;not null"`
+	RoutingKey    string    `gorm:"size:128;not null"`
+	Payload       string    `gorm:"type:text;not null"`
+	Status        int       `gorm:"not null;default:1;index:idx_outbox_dispatch,priority:1"`
+	Attempts      int       `gorm:"not null;default:0"`
+	NextRetryAt   time.Time `gorm:"not null;index:idx_outbox_dispatch,priority:3"`
+	LastError     string    `gorm:"size:512"`
+}
+
+func (OutboxEvent) TableName() string { return "outbox_event" }

--- a/repository/rabbitmq/domain.go
+++ b/repository/rabbitmq/domain.go
@@ -1,0 +1,49 @@
+package rabbitmq
+
+import (
+	"context"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+// 所有业务事件统一进 domain.events 主题交换机
+//   routing key 形如 "order.created" / "stock.reserved" / "product.updated"
+//   消费端 bind 通配符即可订阅自己感兴趣的事件
+const DomainEventsExchange = "domain.events"
+
+// InitDomainEventsExchange 声明拓扑。Init 在 publisher / consumer 启动前都要调一次
+func InitDomainEventsExchange() error {
+	ch, err := GlobalRabbitMQ.Channel()
+	if err != nil {
+		return err
+	}
+	defer ch.Close()
+	return ch.ExchangeDeclare(DomainEventsExchange, "topic", true, false, false, false, nil)
+}
+
+// PublishDomainEvent 发布一条领域事件到主题交换机
+func PublishDomainEvent(ctx context.Context, routingKey string, payload []byte) error {
+	ch, err := GlobalRabbitMQ.Channel()
+	if err != nil {
+		return err
+	}
+	defer ch.Close()
+	return ch.PublishWithContext(ctx, DomainEventsExchange, routingKey, false, false, amqp.Publishing{
+		ContentType:  "application/json",
+		DeliveryMode: amqp.Persistent,
+		Body:         payload,
+	})
+}
+
+// BindDomainQueue 给消费方创建队列并绑定到 domain.events 的某个 routing pattern
+func BindDomainQueue(queue, pattern string) error {
+	ch, err := GlobalRabbitMQ.Channel()
+	if err != nil {
+		return err
+	}
+	defer ch.Close()
+	if _, err := ch.QueueDeclare(queue, true, false, false, false, nil); err != nil {
+		return err
+	}
+	return ch.QueueBind(queue, pattern, DomainEventsExchange, false, nil)
+}

--- a/service/outbox/publisher.go
+++ b/service/outbox/publisher.go
@@ -1,0 +1,86 @@
+package outbox
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	util "github.com/RedInn7/gomall/pkg/utils/log"
+	"github.com/RedInn7/gomall/repository/db/dao"
+	"github.com/RedInn7/gomall/repository/db/model"
+	"github.com/RedInn7/gomall/repository/rabbitmq"
+)
+
+// PublisherConfig 调度参数
+type PublisherConfig struct {
+	PollInterval time.Duration
+	BatchSize    int
+	MaxAttempts  int
+}
+
+func (c PublisherConfig) withDefaults() PublisherConfig {
+	if c.PollInterval <= 0 {
+		c.PollInterval = time.Second
+	}
+	if c.BatchSize <= 0 {
+		c.BatchSize = 100
+	}
+	if c.MaxAttempts <= 0 {
+		c.MaxAttempts = model.OutboxDefaultMaxAttempts
+	}
+	return c
+}
+
+type Publisher struct {
+	cfg     PublisherConfig
+	running atomic.Bool
+}
+
+func New(cfg PublisherConfig) *Publisher {
+	return &Publisher{cfg: cfg.withDefaults()}
+}
+
+// Start 启动后台轮询循环。重复调用是 no-op
+func (p *Publisher) Start(ctx context.Context) {
+	if !p.running.CompareAndSwap(false, true) {
+		return
+	}
+	go p.loop(ctx)
+}
+
+func (p *Publisher) loop(ctx context.Context) {
+	ticker := time.NewTicker(p.cfg.PollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.drainBatch(ctx)
+		}
+	}
+}
+
+// drainBatch 取一批 pending 事件，逐条投递
+func (p *Publisher) drainBatch(ctx context.Context) {
+	if rabbitmq.GlobalRabbitMQ == nil {
+		return
+	}
+	rows, err := dao.NewOutboxDao(ctx).FetchBatch(p.cfg.BatchSize)
+	if err != nil {
+		util.LogrusObj.Errorln("outbox FetchBatch:", err)
+		return
+	}
+	for _, ev := range rows {
+		if err := rabbitmq.PublishDomainEvent(ctx, ev.RoutingKey, []byte(ev.Payload)); err != nil {
+			util.LogrusObj.Errorf("publish outbox event id=%d routing=%s failed: %v", ev.ID, ev.RoutingKey, err)
+			if e := dao.NewOutboxDao(ctx).MarkFailed(ev.ID, ev.Attempts, p.cfg.MaxAttempts, err.Error()); e != nil {
+				util.LogrusObj.Errorln("outbox MarkFailed:", e)
+			}
+			continue
+		}
+		if err := dao.NewOutboxDao(ctx).MarkSent(ev.ID); err != nil {
+			util.LogrusObj.Errorln("outbox MarkSent:", err)
+		}
+	}
+}


### PR DESCRIPTION
- outbox_event 表: 业务事务内插入事件 + 异步 publisher 投递到 domain.events 主题交换机
- DAO: Insert / FetchBatch / MarkSent / MarkFailed (指数退避 + max attempts 后转 dead)
- Publisher goroutine: 启动时拉起，每秒拉一批 pending 事件投到 RMQ
- RMQ 不可用时 publisher 跳过启动，业务事件仍会落库等待重投