### PR TITLE
feat: 商品搜索切换到 ES，通过 outbox + 消费者保持增量索引

### DIFF
--- a/api/v1/admin.go
+++ b/api/v1/admin.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/RedInn7/gomall/pkg/utils/ctl"
 	"github.com/RedInn7/gomall/service"
+	"github.com/RedInn7/gomall/service/search"
 )
 
 func AdminListUsersHandler() gin.HandlerFunc {
@@ -48,5 +49,18 @@ func BootstrapAdminHandler() gin.HandlerFunc {
 			return
 		}
 		c.JSON(http.StatusOK, ctl.RespSuccess(c, gin.H{"ok": true}))
+	}
+}
+
+// AdminBackfillProductIndexHandler 把 DB 中所有 product 灌一遍到 ES (一次性运维操作)
+func AdminBackfillProductIndexHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		batch, _ := strconv.Atoi(c.DefaultQuery("batch", "200"))
+		n, err := search.BackfillFromDB(c.Request.Context(), batch)
+		if err != nil {
+			c.JSON(http.StatusOK, ErrorResponse(c, err))
+			return
+		}
+		c.JSON(http.StatusOK, ctl.RespSuccess(c, gin.H{"indexed": n}))
 	}
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,6 +12,7 @@ import (
 	snowflake "github.com/RedInn7/gomall/pkg/utils/snowflake"
 	"github.com/RedInn7/gomall/repository/cache"
 	"github.com/RedInn7/gomall/repository/db/dao"
+	"github.com/RedInn7/gomall/repository/es"
 	"github.com/RedInn7/gomall/repository/rabbitmq"
 	"github.com/RedInn7/gomall/routes"
 )
@@ -34,7 +35,7 @@ func loading() {
 	initialize.InitInventory(context.Background())
 	tryInitRabbitMQ()
 	initialize.InitOutboxPublisher(context.Background())
-	//es.InitEs()             // 如果需要接入ELK可以打开这个注释
+	tryInitES(context.Background())
 	//kafka.InitKafka()
 	//track.InitJaeger()
 	fmt.Println("加载配置完成...")
@@ -54,4 +55,15 @@ func tryInitRabbitMQ() {
 	}()
 	rabbitmq.InitRabbitMQ()
 	initialize.InitOrderDelayConsumer()
+}
+
+// tryInitES ES 不可用时静默跳过，搜索接口会退回 DB 路径
+func tryInitES(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			util.LogrusObj.Warnf("ES 初始化失败，商品搜索退化到 DB 路径: %v", r)
+		}
+	}()
+	es.InitEs()
+	initialize.InitSearch(ctx)
 }

--- a/initialize/search.go
+++ b/initialize/search.go
@@ -1,0 +1,31 @@
+package initialize
+
+import (
+	"context"
+
+	util "github.com/RedInn7/gomall/pkg/utils/log"
+	"github.com/RedInn7/gomall/repository/es"
+	"github.com/RedInn7/gomall/repository/rabbitmq"
+	"github.com/RedInn7/gomall/service/search"
+)
+
+// InitSearch ES 不可用时静默跳过；RMQ 不可用时仅启用搜索但不接收增量更新
+func InitSearch(ctx context.Context) {
+	if es.EsClient == nil {
+		util.LogrusObj.Warnln("ES 未初始化，跳过搜索索引启动")
+		return
+	}
+	if err := es.EnsureProductIndex(ctx); err != nil {
+		util.LogrusObj.Errorf("EnsureProductIndex failed: %v", err)
+		return
+	}
+	if rabbitmq.GlobalRabbitMQ == nil {
+		util.LogrusObj.Warnln("RMQ 未初始化，仅启用搜索查询，不接收增量索引事件")
+		return
+	}
+	if err := search.StartProductIndexer(ctx); err != nil {
+		util.LogrusObj.Errorf("StartProductIndexer failed: %v", err)
+	} else {
+		util.LogrusObj.Infoln("Product indexer started")
+	}
+}

--- a/repository/es/product_index.go
+++ b/repository/es/product_index.go
@@ -1,0 +1,209 @@
+package es
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/elastic/go-elasticsearch/esapi"
+
+	"github.com/RedInn7/gomall/repository/db/model"
+)
+
+const ProductIndex = "product"
+
+// productIndexMapping IK 分词器 (常用中文搜索) 如果集群没装也能跑，会退回 standard
+var productIndexMapping = `{
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
+  "mappings": {
+    "properties": {
+      "id":             { "type": "long" },
+      "name":           { "type": "text", "analyzer": "standard" },
+      "title":          { "type": "text", "analyzer": "standard" },
+      "info":           { "type": "text", "analyzer": "standard" },
+      "category_id":    { "type": "long" },
+      "price":          { "type": "keyword" },
+      "discount_price": { "type": "keyword" },
+      "on_sale":        { "type": "boolean" },
+      "num":            { "type": "long" },
+      "boss_id":        { "type": "long" },
+      "img_path":       { "type": "keyword" },
+      "created_at":     { "type": "date", "format": "epoch_second" }
+    }
+  }
+}`
+
+// ProductDoc ES 中的商品文档结构，与 model.Product 同构但去掉了 gorm 字段
+type ProductDoc struct {
+	ID            uint   `json:"id"`
+	Name          string `json:"name"`
+	Title         string `json:"title"`
+	Info          string `json:"info"`
+	CategoryID    uint   `json:"category_id"`
+	Price         string `json:"price"`
+	DiscountPrice string `json:"discount_price"`
+	OnSale        bool   `json:"on_sale"`
+	Num           int    `json:"num"`
+	BossID        uint   `json:"boss_id"`
+	ImgPath       string `json:"img_path"`
+	CreatedAt     int64  `json:"created_at"`
+}
+
+func docFromModel(p *model.Product) *ProductDoc {
+	return &ProductDoc{
+		ID:            p.ID,
+		Name:          p.Name,
+		Title:         p.Title,
+		Info:          p.Info,
+		CategoryID:    p.CategoryID,
+		Price:         p.Price,
+		DiscountPrice: p.DiscountPrice,
+		OnSale:        p.OnSale,
+		Num:           p.Num,
+		BossID:        p.BossID,
+		ImgPath:       p.ImgPath,
+		CreatedAt:     p.CreatedAt.Unix(),
+	}
+}
+
+// EnsureProductIndex 幂等地创建索引。已存在则跳过
+func EnsureProductIndex(ctx context.Context) error {
+	if EsClient == nil {
+		return errors.New("es client not initialized")
+	}
+	exists, err := EsClient.Indices.Exists([]string{ProductIndex})
+	if err != nil {
+		return err
+	}
+	defer exists.Body.Close()
+	if exists.StatusCode == 200 {
+		return nil
+	}
+	req := esapi.IndicesCreateRequest{
+		Index: ProductIndex,
+		Body:  bytes.NewReader([]byte(productIndexMapping)),
+	}
+	res, err := req.Do(ctx, EsClient)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.IsError() {
+		body, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("create index failed: %s", string(body))
+	}
+	return nil
+}
+
+// UpsertProduct 写入或更新一条
+func UpsertProduct(ctx context.Context, p *model.Product) error {
+	if EsClient == nil {
+		return errors.New("es client not initialized")
+	}
+	doc := docFromModel(p)
+	body, err := json.Marshal(doc)
+	if err != nil {
+		return err
+	}
+	req := esapi.IndexRequest{
+		Index:      ProductIndex,
+		DocumentID: strconv.FormatUint(uint64(p.ID), 10),
+		Body:       bytes.NewReader(body),
+		Refresh:    "false",
+	}
+	res, err := req.Do(ctx, EsClient)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.IsError() {
+		bz, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("upsert failed: %s", string(bz))
+	}
+	return nil
+}
+
+// DeleteProduct 删除一条
+func DeleteProduct(ctx context.Context, productID uint) error {
+	if EsClient == nil {
+		return errors.New("es client not initialized")
+	}
+	req := esapi.DeleteRequest{
+		Index:      ProductIndex,
+		DocumentID: strconv.FormatUint(uint64(productID), 10),
+		Refresh:    "false",
+	}
+	res, err := req.Do(ctx, EsClient)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	// 404 视作幂等成功
+	if res.IsError() && res.StatusCode != 404 {
+		bz, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("delete failed: %s", string(bz))
+	}
+	return nil
+}
+
+// SearchProducts 多字段模糊查询，返回命中文档 + 总数
+func SearchProducts(ctx context.Context, keyword string, from, size int) ([]*ProductDoc, int64, error) {
+	if EsClient == nil {
+		return nil, 0, errors.New("es client not initialized")
+	}
+	if size <= 0 {
+		size = 20
+	}
+	q := map[string]any{
+		"from": from,
+		"size": size,
+		"query": map[string]any{
+			"multi_match": map[string]any{
+				"query":  keyword,
+				"fields": []string{"name^3", "title^2", "info"},
+			},
+		},
+	}
+	body, _ := json.Marshal(q)
+	req := esapi.SearchRequest{
+		Index: []string{ProductIndex},
+		Body:  bytes.NewReader(body),
+	}
+	res, err := req.Do(ctx, EsClient)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer res.Body.Close()
+	if res.IsError() {
+		bz, _ := io.ReadAll(res.Body)
+		return nil, 0, fmt.Errorf("search failed: %s", string(bz))
+	}
+
+	var parsed struct {
+		Hits struct {
+			Total struct {
+				Value int64 `json:"value"`
+			} `json:"total"`
+			Hits []struct {
+				Source *ProductDoc `json:"_source"`
+			} `json:"hits"`
+		} `json:"hits"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&parsed); err != nil {
+		return nil, 0, err
+	}
+	out := make([]*ProductDoc, 0, len(parsed.Hits.Hits))
+	for _, h := range parsed.Hits.Hits {
+		if h.Source != nil {
+			out = append(out, h.Source)
+		}
+	}
+	return out, parsed.Hits.Total.Value, nil
+}

--- a/routes/router.go
+++ b/routes/router.go
@@ -127,6 +127,7 @@ func NewRouter() *gin.Engine {
 			{
 				admin.GET("users", api.AdminListUsersHandler())
 				admin.POST("users/promote", api.AdminPromoteUserHandler())
+				admin.POST("search/backfill", api.AdminBackfillProductIndexHandler())
 			}
 		}
 	}

--- a/service/product.go
+++ b/service/product.go
@@ -16,6 +16,9 @@ import (
 	"github.com/RedInn7/gomall/repository/cache"
 	"github.com/RedInn7/gomall/repository/db/dao"
 	"github.com/RedInn7/gomall/repository/db/model"
+	"github.com/RedInn7/gomall/repository/es"
+	"github.com/RedInn7/gomall/service/events"
+	"github.com/RedInn7/gomall/service/search"
 	"github.com/RedInn7/gomall/types"
 )
 
@@ -149,6 +152,7 @@ func (s *ProductSrv) ProductCreate(ctx context.Context, files []*multipart.FileH
 		log.LogrusObj.Error("创建产品失败，err:", err)
 		return
 	}
+	emitProductChanged(ctx, product.ID, "create")
 
 	for index, file := range files {
 		num := strconv.Itoa(index)
@@ -246,7 +250,18 @@ func (s *ProductSrv) ProductDelete(ctx context.Context, req *types.ProductDelete
 	}
 	_ = cache.DelProductDetail(ctx, req.ID)
 	cache.DoubleDeleteAsync(req.ID, 0)
+	emitProductChanged(ctx, req.ID, "delete")
 	return
+}
+
+// emitProductChanged 写一条 outbox 事件，由 publisher 异步投到 RMQ 然后被 search.indexer 消费
+func emitProductChanged(ctx context.Context, productID uint, op string) {
+	if err := dao.NewOutboxDao(ctx).Insert(
+		"product", "ProductChanged", "product.changed", productID,
+		events.ProductChanged{ProductID: productID, Op: op},
+	); err != nil {
+		log.LogrusObj.Errorf("emit product.changed event failed product=%d op=%s err=%v", productID, op, err)
+	}
 }
 
 // ProductUpdate 更新商品，延迟双删保证缓存一致性
@@ -271,12 +286,42 @@ func (s *ProductSrv) ProductUpdate(ctx context.Context, req *types.ProductUpdate
 		return
 	}
 	cache.DoubleDeleteAsync(req.ID, 0)
+	emitProductChanged(ctx, req.ID, "update")
 
 	return
 }
 
-// 搜索商品 TODO 后续用脚本同步数据MySQL到ES，用ES进行搜索
+// ProductSearch ES 可用时走 ES 模糊搜索；不可用时退化到 DB SearchProduct
 func (s *ProductSrv) ProductSearch(ctx context.Context, req *types.ProductSearchReq) (resp interface{}, err error) {
+	if es.EsClient != nil {
+		docs, total, esErr := search.SearchProducts(ctx, req)
+		if esErr == nil {
+			pRespList := make([]*types.ProductResp, 0, len(docs))
+			for _, d := range docs {
+				pResp := &types.ProductResp{
+					ID:            d.ID,
+					Name:          d.Name,
+					CategoryID:    d.CategoryID,
+					Title:         d.Title,
+					Info:          d.Info,
+					ImgPath:       d.ImgPath,
+					Price:         d.Price,
+					DiscountPrice: d.DiscountPrice,
+					CreatedAt:     d.CreatedAt,
+					Num:           d.Num,
+					OnSale:        d.OnSale,
+					BossID:        d.BossID,
+				}
+				if conf.Config.System.UploadModel == consts.UploadModelLocal {
+					pResp.ImgPath = conf.Config.PhotoPath.PhotoHost + conf.Config.System.HttpPort + conf.Config.PhotoPath.ProductPath + pResp.ImgPath
+				}
+				pRespList = append(pRespList, pResp)
+			}
+			return &types.DataListResp{Item: pRespList, Total: total}, nil
+		}
+		log.LogrusObj.Errorf("ES search failed, fall back to DB: %v", esErr)
+	}
+
 	products, count, err := dao.NewProductDao(ctx).SearchProduct(req.Info, req.BasePage)
 	if err != nil {
 		log.LogrusObj.Error(err)

--- a/service/search/backfill.go
+++ b/service/search/backfill.go
@@ -1,0 +1,43 @@
+package search
+
+import (
+	"context"
+
+	util "github.com/RedInn7/gomall/pkg/utils/log"
+	"github.com/RedInn7/gomall/repository/db/dao"
+	"github.com/RedInn7/gomall/repository/db/model"
+	"github.com/RedInn7/gomall/repository/es"
+)
+
+// BackfillFromDB 把 product 表全量导入 ES，admin 接口手动触发
+func BackfillFromDB(ctx context.Context, batchSize int) (indexed int, err error) {
+	if batchSize <= 0 {
+		batchSize = 200
+	}
+	if err := es.EnsureProductIndex(ctx); err != nil {
+		return 0, err
+	}
+	db := dao.NewDBClient(ctx)
+	var lastID uint
+	for {
+		var rows []*model.Product
+		q := db.Model(&model.Product{}).Order("id ASC").Limit(batchSize)
+		if lastID > 0 {
+			q = q.Where("id > ?", lastID)
+		}
+		if e := q.Find(&rows).Error; e != nil {
+			return indexed, e
+		}
+		if len(rows) == 0 {
+			return indexed, nil
+		}
+		for _, p := range rows {
+			if e := es.UpsertProduct(ctx, p); e != nil {
+				util.LogrusObj.Errorf("backfill upsert product=%d failed: %v", p.ID, e)
+				continue
+			}
+			indexed++
+			lastID = p.ID
+		}
+	}
+}

--- a/service/search/indexer.go
+++ b/service/search/indexer.go
@@ -1,0 +1,60 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+
+	util "github.com/RedInn7/gomall/pkg/utils/log"
+	"github.com/RedInn7/gomall/repository/db/dao"
+	"github.com/RedInn7/gomall/repository/es"
+	"github.com/RedInn7/gomall/repository/rabbitmq"
+	"github.com/RedInn7/gomall/service/events"
+)
+
+const indexerQueue = "search.product.indexer"
+
+// StartProductIndexer 绑定 product.changed 并启动消费者，把产品变更同步到 ES
+func StartProductIndexer(ctx context.Context) error {
+	if err := rabbitmq.BindDomainQueue(indexerQueue, "product.changed"); err != nil {
+		return err
+	}
+	ch, err := rabbitmq.GlobalRabbitMQ.Channel()
+	if err != nil {
+		return err
+	}
+	if err := ch.Qos(32, 0, false); err != nil {
+		return err
+	}
+	msgs, err := ch.Consume(indexerQueue, "", false, false, false, false, nil)
+	if err != nil {
+		return err
+	}
+	go func() {
+		for d := range msgs {
+			var ev events.ProductChanged
+			if err := json.Unmarshal(d.Body, &ev); err != nil {
+				util.LogrusObj.Errorln("indexer parse event:", err)
+				_ = d.Nack(false, false)
+				continue
+			}
+			if err := handleProductChanged(ctx, ev); err != nil {
+				util.LogrusObj.Errorf("indexer handle product=%d op=%s err=%v", ev.ProductID, ev.Op, err)
+				_ = d.Nack(false, true)
+				continue
+			}
+			_ = d.Ack(false)
+		}
+	}()
+	return nil
+}
+
+func handleProductChanged(ctx context.Context, ev events.ProductChanged) error {
+	if ev.Op == "delete" {
+		return es.DeleteProduct(ctx, ev.ProductID)
+	}
+	p, err := dao.NewProductDao(ctx).GetProductById(ev.ProductID)
+	if err != nil || p == nil {
+		return err
+	}
+	return es.UpsertProduct(ctx, p)
+}

--- a/service/search/service.go
+++ b/service/search/service.go
@@ -1,0 +1,48 @@
+package search
+
+import (
+	"context"
+
+	"github.com/RedInn7/gomall/repository/es"
+	"github.com/RedInn7/gomall/types"
+)
+
+// SearchProducts 调用 ES 多字段模糊匹配。keyword 取请求里的 info / title / name 任意非空字段
+func SearchProducts(ctx context.Context, req *types.ProductSearchReq) ([]*es.ProductDoc, int64, error) {
+	kw := firstNonEmpty(req.Info, req.Title, req.Name)
+	req.BasePage.Normalize()
+	from := (req.PageNum - 1) * req.PageSize
+	return es.SearchProducts(ctx, kw, from, req.PageSize)
+}
+
+// Backfill 把 DB 中现存商品全量灌进 ES (按 id 批量扫)
+func Backfill(ctx context.Context, batchSize int, fetcher func(lastID uint, limit int) ([]uint, error), loader func(id uint) error) error {
+	if batchSize <= 0 {
+		batchSize = 200
+	}
+	var last uint
+	for {
+		ids, err := fetcher(last, batchSize)
+		if err != nil {
+			return err
+		}
+		if len(ids) == 0 {
+			return nil
+		}
+		for _, id := range ids {
+			if err := loader(id); err != nil {
+				return err
+			}
+			last = id
+		}
+	}
+}
+
+func firstNonEmpty(s ...string) string {
+	for _, v := range s {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
- repository/es/product_index.go: 创建/Upsert/Delete/Search API + 索引 mapping (multi_match: name^3 / title^2 / info)
- service/search/indexer.go: 订阅 product.changed 事件，更新/删除 ES 文档
- service/search/service.go: 高层搜索 API
- service/search/backfill.go: 全量回填 (admin 接口手动触发)
- service/product.go:
  - Create / Update / Delete 后写 outbox 事件 (product.changed)
  - ProductSearch 优先走 ES；ES 不可用时回退到原 DB SearchProduct
- cmd/main.go: tryInitES (失败不阻塞启动；ES + RMQ 都正常才接入实时索引)
- routes/router.go: 新增 POST /admin/search/backfill (RBAC admin 限制)