### PR TITLE
hardening(sre): 优雅关闭 + 雪花强校验 + 转账锁序防死锁 + 连接池调优

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,9 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
+	"time"
 
 	_ "github.com/apache/skywalking-go"
 
@@ -23,10 +27,38 @@ import (
 )
 
 func main() {
-	loading() // 加载配置
+	loading()
 	r := routes.NewRouter()
-	_ = r.Run(conf.Config.System.HttpPort)
+
+	srv := &http.Server{
+		Addr:              conf.Config.System.HttpPort,
+		Handler:           r,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			util.LogrusObj.Fatalf("server error: %v", err)
+		}
+	}()
+
+	util.LogrusObj.Infof("server listening on %s", conf.Config.System.HttpPort)
 	fmt.Println("启动配成功...")
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	<-quit
+
+	util.LogrusObj.Info("shutting down server...")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		util.LogrusObj.Errorf("server forced shutdown: %v", err)
+	}
+	util.LogrusObj.Info("shutdown complete")
 }
 
 // loading一些配置
@@ -55,22 +87,31 @@ func loading() {
 	fmt.Println("加载配置完成...")
 }
 
-// snowflakeNodeID 从环境变量 SNOWFLAKE_NODE_ID（或 NODE_ID）读取雪花算法节点 ID，
-// 多实例部署时每个副本配置不同值以避免 ID 碰撞，缺省为 0。
+// snowflakeNodeID 从环境变量 SNOWFLAKE_NODE_ID（或 NODE_ID）读取雪花算法节点 ID。
+// 多实例部署时每个副本必须配置唯一值（0..1023），否则启动被拒绝以防止 ID 碰撞。
+// 仅在设置 SNOWFLAKE_ALLOW_DEFAULT=true 时允许省略，退回节点 0（限本地开发/测试）。
 func snowflakeNodeID() int64 {
 	for _, envKey := range []string{"SNOWFLAKE_NODE_ID", "NODE_ID"} {
 		if raw := strings.TrimSpace(os.Getenv(envKey)); raw != "" {
 			n, err := strconv.ParseInt(raw, 10, 64)
 			if err != nil {
-				util.LogrusObj.Warnf("snowflakeNodeID: invalid %s=%q, fallback to 0: %v", envKey, raw, err)
-				return 0
+				util.LogrusObj.Fatalf("snowflakeNodeID: %s=%q is not a valid integer: %v", envKey, raw, err)
+			}
+			if n < 0 || n > 1023 {
+				util.LogrusObj.Fatalf("snowflakeNodeID: %s=%d is out of range [0, 1023]", envKey, n)
 			}
 			util.LogrusObj.Infof("snowflakeNodeID: using node id %d from env %s", n, envKey)
 			return n
 		}
 	}
-	util.LogrusObj.Infoln("snowflakeNodeID: SNOWFLAKE_NODE_ID / NODE_ID not set, defaulting to 0")
-	return 0
+
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("SNOWFLAKE_ALLOW_DEFAULT")), "true") {
+		util.LogrusObj.Warn("snowflakeNodeID: SNOWFLAKE_NODE_ID / NODE_ID not set; SNOWFLAKE_ALLOW_DEFAULT=true — defaulting to node 0 (local dev/test only, NOT safe for multi-replica)")
+		return 0
+	}
+
+	util.LogrusObj.Fatal("snowflakeNodeID: SNOWFLAKE_NODE_ID (or NODE_ID) must be set for each replica to prevent ID collisions; set SNOWFLAKE_ALLOW_DEFAULT=true to override for local dev")
+	return 0 // unreachable, satisfies compiler
 }
 
 // tryInitRabbitMQ 初始化 RabbitMQ 连接与延迟队列消费者。

--- a/internal/payment/service.go
+++ b/internal/payment/service.go
@@ -82,8 +82,9 @@ func (s *PaymentSrv) PayDown(ctx context.Context, req *PaymentDownReq) (resp *Pa
 		}
 
 		userDao := user.NewUserDaoByDB(tx)
-		// 先校验支付密码（与余额加密分离），再做加行锁的余额读改写
-		buyer, err := userDao.GetUserByIdForUpdate(uId)
+		// 统一锁序：按 user id 升序对买卖双方一并加 FOR UPDATE，消除 A 向 B 下单与 B 向 A
+		// 下单并发时“先买家后卖家”角色锁序构成的锁环死锁。锁就位后再校验支付密码、读改写余额。
+		buyer, boss, err := userDao.LockTwoUsersForUpdate(uId, bossID)
 		if err != nil {
 			log.LogrusObj.Error(err)
 			return err
@@ -124,12 +125,7 @@ func (s *PaymentSrv) PayDown(ctx context.Context, req *PaymentDownReq) (resp *Pa
 			return err
 		}
 
-		boss, err := userDao.GetUserByIdForUpdate(bossID)
-		if err != nil {
-			log.LogrusObj.Error(err)
-			return err
-		}
-
+		// boss 已在事务开头随 buyer 一并按 id 序加锁，无需二次读取。
 		// 商家余额同样用服务端密钥解密——绝不能用买家支付密码，否则跨账户串密钥
 		bossMoney, err := boss.DecryptMoney()
 		if err != nil {

--- a/internal/user/repo.go
+++ b/internal/user/repo.go
@@ -100,6 +100,37 @@ func (d *UserDao) GetUserByIdForUpdate(uId uint) (user *User, err error) {
 	return
 }
 
+// LockTwoUsersForUpdate 按 id 升序对两个用户行加 FOR UPDATE 后返回（a 对应 idA，b 对应 idB）。
+// 转账类操作（支付、退款、定金划转）会同时锁定买家与卖家两行；若各事务按各自的
+// “买家→卖家”业务顺序加锁，用户 A 向 B 下单（锁 A→锁 B）与 B 向 A 下单（锁 B→锁 A）
+// 并发时即构成循环等待死锁。统一按 id 排序加锁，使所有事务的多锁获取顺序全局一致，
+// 从根上消除死锁。idA==idB（自购自卖）时只锁一次，两个返回值指向同一对象。
+func (d *UserDao) LockTwoUsersForUpdate(idA, idB uint) (a, b *User, err error) {
+	if idA == idB {
+		only, e := d.GetUserByIdForUpdate(idA)
+		if e != nil {
+			return nil, nil, e
+		}
+		return only, only, nil
+	}
+	first, second := idA, idB
+	if idB < idA {
+		first, second = idB, idA
+	}
+	u1, e := d.GetUserByIdForUpdate(first)
+	if e != nil {
+		return nil, nil, e
+	}
+	u2, e := d.GetUserByIdForUpdate(second)
+	if e != nil {
+		return nil, nil, e
+	}
+	if first == idA {
+		return u1, u2, nil
+	}
+	return u2, u1, nil
+}
+
 // UpdateUserById 根据 id 更新用户信息
 func (d *UserDao) UpdateUserById(uId uint, user *User) (err error) {
 	return d.DB.Model(&User{}).Where("id=?", uId).

--- a/repository/db/dao/init.go
+++ b/repository/db/dao/init.go
@@ -47,9 +47,10 @@ func InitMySQL() {
 		panic(err)
 	}
 	sqlDB, _ := db.DB()
-	sqlDB.SetMaxIdleConns(20)  // 设置连接池，空闲
-	sqlDB.SetMaxOpenConns(100) // 打开
-	sqlDB.SetConnMaxLifetime(time.Second * 30)
+	sqlDB.SetMaxIdleConns(20)
+	sqlDB.SetMaxOpenConns(100)
+	sqlDB.SetConnMaxLifetime(5 * time.Minute)
+	sqlDB.SetConnMaxIdleTime(5 * time.Minute)
 	_db = db
 	_ = _db.Use(dbresolver.
 		Register(dbresolver.Config{


### PR DESCRIPTION
## 背景
SRE 运维加固第一波。原 `harden/sre-wave1-ops` 分支基于一条**已被重写掉的旧历史根**，与当前 `main` 无共同祖先，无法直接 PR/merge。排查发现 `main` 早已独立实现了大部分加固，且更完善（MQ 自愈 + DLQ + x-death 毒丸判定、资金流水台账、双删在途计数）。

故本 PR **只补 `main` 尚缺的四块**，不触碰 main 已更优的 MQ / cache 逻辑（避免回退）。

## 改动
- **优雅关闭 / server 超时**（cmd/main）：`http.Server` 设超时 + 监听 SIGINT/SIGTERM 平滑下线。
- **雪花 nodeID 强校验**：缺失/越界改为拒绝启动（原来默默退回 0，多副本会生成重复订单 ID），仅 `SNOWFLAKE_ALLOW_DEFAULT=true` 放行本地开发。
- **转账锁序防死锁**（user/payment）：新增 `LockTwoUsersForUpdate`，对买卖双方按 user id 升序加 `FOR UPDATE`，消除 "A→B / B→A 并发下单" 锁环死锁；`PayDown` 改用它一次锁定双方并删除冗余二次锁 boss，**保留 main 的资金台账逻辑不变**。
- **连接池调优**（db）：`ConnMaxLifetime` 30s→5min，新增 `ConnMaxIdleTime`。

## 已丢弃（main 已有更优实现）
- MQ 消费自愈：main 的 `SuperviseDomainConsumer` / `superviseConsumer` 已含 DLQ 死信路由 + x-death 投递次数毒丸判定，强于本分支的 `StartConsumer`。
- 双删 goroutine recover：main 已有 `doubleDeleteInflight` 在途计数。

## 验证
- `go build ./...` ✅  `go vet ./...` ✅
- `go test`（隔离）payment / user / preorder 均通过 ✅